### PR TITLE
set ci rust toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 name: CI
 
 env:
-  CI_RUST_TOOLCHAIN: 1.46.0
+  CI_RUST_TOOLCHAIN: 1.47.0
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 on: [push, pull_request]
 
-name: Rust-CI
+name: CI
+
+env:
+  CI_RUST_TOOLCHAIN: 1.46.0
 
 jobs:
   check:
@@ -11,7 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -25,7 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -39,7 +42,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -55,10 +58,10 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ env.CI_RUST_TOOLCHAIN }}
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all -- -D warnings
+          args: --all-targets --all-features -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@
 )]
 #![allow(
     // Some explicitly allowed Clippy lints, must have clear reason to allow
+    clippy::blanket_clippy_restriction_lints, // allow clippy::restriction
+    clippy::panic, // allow debug_assert, panic in production code
     clippy::implicit_return, // actually omitting the return keyword is idiomatic Rust code
 )]
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -26,10 +26,11 @@ impl<T> AtomicPtr<T> {
     }
 
     /// `new` creates the `value` on heap and returns its `AtomicPtr`.
+    #[allow(clippy::as_conversions)]
     pub fn new(value: T) -> Self {
         let b = Box::new(value);
         let raw_ptr = Box::into_raw(b);
-        unsafe { Self::from_usize(std::mem::transmute::<*const T, usize>(raw_ptr)) }
+        Self::from_usize(raw_ptr as usize)
     }
 
     /// `null` returns a `AtomicPtr` with a null pointer.
@@ -98,8 +99,9 @@ impl<T> SharedPtr<'_, T> {
     }
 
     /// `from_raw` creates a `SharedPtr` from a raw pointer.
+    #[allow(clippy::as_conversions)]
     pub fn from_raw(raw: *const T) -> Self {
-        unsafe { Self::from_usize(std::mem::transmute::<*const T, usize>(raw)) }
+        Self::from_usize(raw as usize)
     }
 
     /// `null` returns a null `SharedPtr`.

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -1,5 +1,4 @@
 use lockfree_cuckoohash::{pin, LockFreeCuckooHash};
-use num_cpus;
 use rand::Rng;
 use std::sync::Arc;
 use std::time::Instant;


### PR DESCRIPTION
This PR:
1. set the CI rust toolchain version as 1.47.0.
2. fix the clippy lint error in benchmark.rs